### PR TITLE
Refactor merge_constraint

### DIFF
--- a/.github/workflows/build-cross.yml
+++ b/.github/workflows/build-cross.yml
@@ -90,6 +90,8 @@ jobs:
           ./configure --prefix="$HOME/cross" --target=x86_64-w64-mingw32 \
               TARGET_LIBDIR="$TESTDIR" || res=$?
           if ! [ "$res" = 0 ]; then cat config.log; exit "$res"; fi
+          # The OOM-killer may be triggered if the number of parallel
+          # jobs isn't limited.
           make crossopt -j$(nproc)
           make installcross
           ln -sr "$HOME/cross/bin/flexlink.opt.exe" "$HOME/.local/bin/flexlink"

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v3
         with:
-          packages: make,bash,mingw64-x86_64-gcc-core
+          packages: make,mingw64-x86_64-gcc-core
           install-dir: 'D:\cygwin'
 
       - name: Save Cygwin cache

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -35,14 +35,6 @@ jobs:
             x86_64: false
 
     steps:
-      - name: Save pristine PATH
-        run: |
-          echo "PRISTINE_PATH=${env:Path}" >> "${env:GITHUB_ENV}"
-
-      - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Fetch OCaml
         uses: actions/checkout@v4
@@ -51,8 +43,6 @@ jobs:
 
       - name: Restore Cygwin cache
         uses: actions/cache/restore@v4
-        env:
-          PATH: ${{ env.PRISTINE_PATH }}
         with:
           path: |
             C:\cygwin-packages
@@ -66,12 +56,15 @@ jobs:
 
       - name: Save Cygwin cache
         uses: actions/cache/save@v4
-        env:
-          PATH: ${{ env.PRISTINE_PATH }}
         with:
           path: |
             C:\cygwin-packages
           key: cygwin-packages
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Compute a key to cache configure results
         shell: bash

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -87,15 +87,16 @@ jobs:
       - name: Build OCaml
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
-          CC: ${{ matrix.cc }}
         run: |
           eval $(tools/msvs-promote-path)
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC \
-               --prefix "$PROGRAMFILES/Бактріан🐫"; then
+          if ! ./configure --cache-file=config.cache --host=$HOST \
+               --prefix="$PROGRAMFILES/Бактріан🐫" \
+               CC=${{ matrix.cc }}; then
             rm -rf config.cache
             failed=0
-            ./configure --cache-file=config.cache --host=$HOST CC=$CC \
-                --prefix "$PROGRAMFILES/Бактріан🐫" \
+            ./configure --cache-file=config.cache --host=$HOST \
+                --prefix="$PROGRAMFILES/Бактріан🐫" \
+                CC=${{ matrix.cc }} \
               || failed=$?
             if ((failed)) ; then cat config.log ; exit $failed ; fi
           fi

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -16,6 +16,10 @@ on:
   # Fully print commands executed by Make
   # MAKEFLAGS: V=1
 
+defaults:
+  run:
+    shell: bash -eo pipefail -o igncr {0}
+
 jobs:
   build:
     permissions: {}
@@ -67,11 +71,10 @@ jobs:
           arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Compute a key to cache configure results
-        shell: bash
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
           CC: ${{ matrix.cc }}
-        run: >-
+        run: |
           echo "AUTOCONF_CACHE_KEY=$HOST-$CC-$({ cat configure; uname; } | sha1sum | cut -c 1-7)" >> $GITHUB_ENV
 
       - name: Restore Autoconf cache
@@ -82,27 +85,23 @@ jobs:
           key: ${{ env.AUTOCONF_CACHE_KEY }}
 
       - name: Build OCaml
-        shell: bash
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
           CC: ${{ matrix.cc }}
-        run: >-
-          eval $(tools/msvs-promote-path) ;
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC
-          --prefix "$PROGRAMFILES/Бактріан🐫"; then
-          rm -rf config.cache ;
-          failed=0 ;
-          ./configure --cache-file=config.cache --host=$HOST CC=$CC
-          --prefix "$PROGRAMFILES/Бактріан🐫"
-          || failed=$?;
-          if ((failed)) ; then cat config.log ; exit $failed ; fi ;
-          fi ;
-          make -j || failed=$? ;
-          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi ;
-          runtime/ocamlrun ocamlc -config ;
-        # Don't add indentation or comments, it breaks Bash on
-        # Windows when the yaml text block scalar is processed as a
-        # single line.
+        run: |
+          eval $(tools/msvs-promote-path)
+          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+               --prefix "$PROGRAMFILES/Бактріан🐫"; then
+            rm -rf config.cache
+            failed=0
+            ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+                --prefix "$PROGRAMFILES/Бактріан🐫" \
+              || failed=$?
+            if ((failed)) ; then cat config.log ; exit $failed ; fi
+          fi
+          make -j || failed=$?
+          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
+          runtime/ocamlrun ocamlc -config
 
       - name: Save Autoconf cache
         uses: actions/cache/save@v4
@@ -112,26 +111,23 @@ jobs:
           key: ${{ env.AUTOCONF_CACHE_KEY }}
 
       - name: Assemble backend with MinGW GASM and compare
-        shell: bash
-        run: >-
-          x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S ;
-          dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump ;
-          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64nt.dump runtime/amd64nt.dump > runtime/amd64nt.canonical ;
-          dumpbin /disasm:nobytes runtime/amd64.o > runtime/amd64.dump ;
-          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64.dump runtime/amd64.dump > runtime/amd64.canonical ;
-          git diff --no-index -- runtime/amd64*.canonical ;
-          wc -l runtime/amd64*.dump runtime/amd64*.canonical ;
+        run: |
+          x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S
+          dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump
+          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64nt.dump runtime/amd64nt.dump > runtime/amd64nt.canonical
+          dumpbin /disasm:nobytes runtime/amd64.o > runtime/amd64.dump
+          awk -f tools/ci/actions/canonicalize-dumpbin.awk runtime/amd64.dump runtime/amd64.dump > runtime/amd64.canonical
+          git diff --no-index -- runtime/amd64*.canonical
+          wc -l runtime/amd64*.dump runtime/amd64*.canonical
         # ^ The final wc is there to make sure that the canonical files are
         # reasonable cleaned-up versions of the raw dumpbins and not simply
         # empty
         if: matrix.x86_64
 
       - name: Run the test suite
-        shell: bash
-        run: >-
-          eval $(tools/msvs-promote-path) ;
-          make -j tests ;
+        run: |
+          eval $(tools/msvs-promote-path)
+          make -j tests
 
       - name: Install the compiler
-        shell: bash
         run: make install

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -98,7 +98,13 @@ jobs:
                 --prefix="$PROGRAMFILES/Бактріан🐫" \
                 CC=${{ matrix.cc }} \
               || failed=$?
-            if ((failed)) ; then cat config.log ; exit $failed ; fi
+            if ((failed)) ; then
+              echo
+              echo "::group::config.log content ($(wc -l config.log) lines)"
+              cat config.log
+              echo '::endgroup::'
+              exit $failed
+            fi
           fi
 
       - name: Save Autoconf cache

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -71,18 +71,18 @@ jobs:
           arch: ${{ matrix.x86_64 && 'x64' || 'x86' }}
 
       - name: Compute a key to cache configure results
+        id: autoconf-cache-key
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
-          CC: ${{ matrix.cc }}
         run: |
-          echo "AUTOCONF_CACHE_KEY=$HOST-$CC-$({ cat configure; uname; } | sha1sum | cut -c 1-7)" >> $GITHUB_ENV
+          echo "key=${{ env.HOST }}-${{ matrix.cc }}-${{ hashFiles('configure') }}" >> $GITHUB_OUTPUT
 
       - name: Restore Autoconf cache
         uses: actions/cache/restore@v4
         with:
           path: |
             config.cache
-          key: ${{ env.AUTOCONF_CACHE_KEY }}
+          key: ${{ steps.autoconf-cache-key.outputs.key }}
 
       - name: Build OCaml
         env:
@@ -108,7 +108,7 @@ jobs:
         with:
           path: |
             config.cache
-          key: ${{ env.AUTOCONF_CACHE_KEY }}
+          key: ${{ steps.autoconf-cache-key.outputs.key }}
 
       - name: Assemble backend with MinGW GASM and compare
         run: |

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run the test suite
         run: |
           eval $(tools/msvs-promote-path)
-          make -j tests
+          make tests
 
       - name: Install the compiler
         run: make install

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -84,7 +84,7 @@ jobs:
             config.cache
           key: ${{ steps.autoconf-cache-key.outputs.key }}
 
-      - name: Build OCaml
+      - name: Configure tree
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
         run: |
@@ -100,9 +100,6 @@ jobs:
               || failed=$?
             if ((failed)) ; then cat config.log ; exit $failed ; fi
           fi
-          make -j || failed=$?
-          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
-          runtime/ocamlrun ocamlc -config
 
       - name: Save Autoconf cache
         uses: actions/cache/save@v4
@@ -111,7 +108,14 @@ jobs:
             config.cache
           key: ${{ steps.autoconf-cache-key.outputs.key }}
 
-      - name: Assemble backend with MinGW GASM and compare
+      - name: Build OCaml
+        run: |
+          eval $(tools/msvs-promote-path)
+          make -j || failed=$?
+          if ((failed)) ; then make -j1 V=1 ; exit $failed ; fi
+          runtime/ocamlrun ocamlc -config
+
+      - name: Assemble backend with mingw-w64 GASM and compare
         run: |
           x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S
           dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump

--- a/Changes
+++ b/Changes
@@ -150,6 +150,9 @@ Working version
 
 ### Standard library:
 
+- #13696: Add Result.product and Result.Syntax.
+  (Daniel Bünzli, review by Gabriel Scherer, Nicolás Ojeda Bär)
+
 - #13885: Add Dynarray.{exists2, for_all2}.
   (T. Kinsart, review by Daniel Bünzli, Gabriel Scherer, and Nicolás Ojeda Bär)
 

--- a/Changes
+++ b/Changes
@@ -352,9 +352,9 @@ Working version
   change locations of error messages when `S` is ill-typed in `(module S)`
   (Samuel Vivien, review by Florian Angeletti and Gabriel Scherer)
 
-- #13814: Add an `unused-type-declaration` when using a `t as 'a` with no other
-  occurences of `'a`
-  (Samuel Vivien, review by Florian Angeletti)
+- #13814, 13898: Add an `unused-type-declaration` when using a `t as 'a` with
+  no other occurences of `'a`
+  (Samuel Vivien, review by Florian Angeletti, Kate Deplaix)
 
 - #13817: align spellchecking hints with the possibly misspelled identifier/
               Error: Unbound type constructor "aray"

--- a/Changes
+++ b/Changes
@@ -514,6 +514,10 @@ Working version
   definitions
   (Clement Blaudeau, review by Florian Angeletti)
 
+* #13874, #13882: Make evaluation order consistent for applications when using
+  the non-flambda native compiler
+  (Vincent Laviron, report by Jean-Marie Madiot, review by Gabriel Scherer)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/Changes
+++ b/Changes
@@ -298,6 +298,10 @@ Working version
   odoc behaviour).
   (Florian Angeletti, review by Gabriel Scherer)
 
+- #13906: Add support for a `multicore` tag in ocamltest and use it for
+  tests that fail on mono-core systems.
+  (Stéphane Glondu, review by Nicolás Ojeda Bär)
+
 ### Manual and documentation:
 
 - #13694: Fix name for caml_hash_variant in the C interface.

--- a/Changes
+++ b/Changes
@@ -421,6 +421,10 @@ Working version
   parser is modified too to accept `+-` and `-+` as `type_variance`.
   (Takafumi Saikawa and Jacques Garrigue, review by Florian Angeletti)
 
+- #13828: Apply BUILD_PATH_PREFIX_MAP to Sys.argv.(0) before storing it in .cmt
+  and .cmti files.
+  (David Allsopp, review by Daniel Bünzli and Gabriel Scherer)
+
 - #13848: Add all paths components to the cmt files indexes
   (Ulysse Gérard, review by Florian Angeletti)
 

--- a/Changes
+++ b/Changes
@@ -510,6 +510,10 @@ Working version
 - #13880: Make object stat counters atomic
   (Dimitris Mostrous, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #13172, #13829: Fix a missing check of illegal recursive module-type
+  definitions
+  (Clement Blaudeau, review by Florian Angeletti)
+
 OCaml 5.3.0 (8 January 2025)
 ----------------------------
 

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -477,12 +477,16 @@ let save_cmt target binary_annots initial_env cmi shape =
          let cmt_annots = clear_env binary_annots in
          let cmt_uid_to_decl = index_declarations cmt_annots in
          let source_digest = Option.map Digest.file sourcefile in
+         let cmt_args =
+           let cmt_args = Array.copy Sys.argv in
+           cmt_args.(0) <- Location.rewrite_absolute_path Sys.argv.(0);
+           cmt_args in
          let cmt = {
            cmt_modname = Unit_info.Artifact.modname target;
            cmt_annots;
            cmt_declaration_dependencies = !uids_deps;
            cmt_comments = Lexer.comments ();
-           cmt_args = Sys.argv;
+           cmt_args;
            cmt_sourcefile = sourcefile;
            cmt_builddir = Location.rewrite_absolute_path (Sys.getcwd ());
            cmt_loadpath = Load_path.get_paths ();

--- a/file_formats/cmt_format.mli
+++ b/file_formats/cmt_format.mli
@@ -57,6 +57,8 @@ type cmt_infos = {
   cmt_declaration_dependencies : (dependency_kind * Uid.t * Uid.t) list;
   cmt_comments : (string * Location.t) list;
   cmt_args : string array;
+    (** {!Sys.argv} from the compiler invocation which created the file.
+        [Sys.argv.(0)] is rewritten using [BUILD_PATH_PREFIX_MAP]. *)
   cmt_sourcefile : string option;
   cmt_builddir : string;
   cmt_loadpath : Load_path.paths;

--- a/manual/src/cmds/intf-c.etex
+++ b/manual/src/cmds/intf-c.etex
@@ -781,7 +781,7 @@ of a value \var{v} of any boxed type (record or concrete data type).
 \item "caml_field_unboxable("\var{v}")" calls either
 "caml_field_unboxed" or "caml_field_boxed" according to the default
 representation of unboxable types in the current version of OCaml.
-\item "Some_val("\var{v}")" returns the argument "\var{x}" of a value \var{v} of
+\item "Some_val("\var{v}")" returns the argument \var{x} of a value \var{v} of
 the form "Some("\var{x}")".
 \end{itemize}
 The expressions "Field("\var{v}", "\var{n}")",
@@ -1535,19 +1535,19 @@ re-raising the exception (if any) or continuing the computation.
 "caml_result" values can be manipulated using the following functions
 and macros:
 \begin{itemize}
-\item "value caml_get_value_or_raise(caml_result \var{res})"
+\item "value caml_get_value_or_raise(caml_result "\var{res}")"
   (in "fail.h") returns the value contained in \var{res} or reraises
   the exception it contains. In particular,
   "(void)caml_get_value_or_raise(res)" can be used to ignore an OCaml
   result of type "unit", yet propagate exceptions to the caller.
 
-\item "Result_value(value \var{v})" (in "mlvalues.h") is the result
+\item "Result_value(value "\var{v}")" (in "mlvalues.h") is the result
   that represents returning the value \var{v}.
 
-\item "Result_exception(value \var{exn})" (in "mlvalues.h") is the
+\item "Result_exception(value "\var{exn}")" (in "mlvalues.h") is the
   result that represents raising the exception \var{exn}.
 
-\item "int caml_result_is_exception(caml_result \var{res})"
+\item "int caml_result_is_exception(caml_result "\var{res}")"
   (in "mlvalues.h") is true if \var{res} represents an exception.
 
 \item The macro "CAMLlocalresult(foo)" (in "memory.h") is the

--- a/manual/src/tutorials/parallelism.etex
+++ b/manual/src/tutorials/parallelism.etex
@@ -63,7 +63,7 @@ number is given below.
 (* fib.ml *)
 let n = try int_of_string Sys.argv.(1) with _ -> 1
 
-let rec fib n = if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+let rec fib n = if n < 2 then n else fib (n - 1) + fib (n - 2)
 
 let main () =
   let r = fib n in
@@ -77,7 +77,7 @@ The program can be compiled and benchmarked as follows:
 \begin{verbatim}
 $ ocamlopt -o fib.exe fib.ml
 $ ./fib.exe 42
-fib(42) = 433494437
+fib(42) = 267914296
 $ hyperfine './fib.exe 42' # Benchmarking
 Benchmark 1: ./fib.exe 42
   Time (mean ± sd):     1.193 s ±  0.006 s    [User: 1.186 s, System: 0.003 s]
@@ -94,7 +94,7 @@ computes the $n$th Fibonacci number twice in parallel.
 (* fib_twice.ml *)
 let n = int_of_string Sys.argv.(1)
 
-let rec fib n = if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+let rec fib n = if n < 2 then n else fib (n - 1) + fib (n - 2)
 
 let main () =
   let d1 = Domain.spawn (fun _ -> fib n) in
@@ -115,8 +115,8 @@ computation runs to completion.
 \begin{verbatim}
 $ ocamlopt -o fib_twice.exe fib_twice.ml
 $ ./fib_twice.exe 42
-fib(42) = 433494437
-fib(42) = 433494437
+fib(42) = 267914296
+fib(42) = 267914296
 $ hyperfine './fib_twice.exe 42'
 Benchmark 1: ./fib_twice.exe 42
   Time (mean ± sd):     1.249 s ±  0.025 s    [User: 2.451 s, System: 0.012 s]
@@ -137,7 +137,7 @@ by spawning domains for each one will not work as it spawns too many domains.
 let n = try int_of_string Sys.argv.(1) with _ -> 1
 
 let rec fib n =
-  if n < 2 then 1 else begin
+  if n < 2 then n else begin
     let d1 = Domain.spawn (fun _ -> fib (n - 1)) in
     let d2 = Domain.spawn (fun _ -> fib (n - 2)) in
     Domain.join d1 + Domain.join d2
@@ -184,7 +184,7 @@ of the Fibonacci program follows:
 let num_domains = int_of_string Sys.argv.(1)
 let n = int_of_string Sys.argv.(2)
 
-let rec fib n = if n < 2 then 1 else fib (n - 1) + fib (n - 2)
+let rec fib n = if n < 2 then n else fib (n - 1) + fib (n - 2)
 
 module T = Domainslib.Task
 
@@ -232,7 +232,7 @@ programs that use libraries installed through
 \begin{verbatim}
 $ ocamlfind ocamlopt -package domainslib -linkpkg -o fib_par2.exe fib_par2.ml
 $ ./fib_par2.exe 1 42
-fib(42) = 433494437
+fib(42) = 267914296
 $ hyperfine './fib.exe 42' './fib_par2.exe 2 42' \
             './fib_par2.exe 4 42' './fib_par2.exe 8 42'
 Benchmark 1: ./fib.exe 42

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -102,6 +102,13 @@ let hasstr = make
     "str library available"
     "str library not available")
 
+let multicore = make
+  ~name:"multicore"
+  ~description:"Pass if running on multicore"
+  (Actions_helpers.pass_or_skip (Domain.recommended_domain_count () >= 2)
+    "running on multicore"
+    "not running on multicore")
+
 let windows_OS = "Windows_NT"
 
 let get_OS () = Sys.safe_getenv "OS"
@@ -392,6 +399,7 @@ let _ =
     hasunix;
     hassysthreads;
     hasstr;
+    multicore;
     libunix;
     libwin32unix;
     windows;

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -168,8 +168,9 @@ val equal : ('a -> 'a -> bool) -> 'a array -> 'a array -> bool
     @since 5.4 *)
 
 val compare : ('a -> 'a -> int) -> 'a array -> 'a array -> int
-(** [compare cmp a b] orders [a] and [b] in lexicographic order
-    using [cmp] to compare elements.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -168,8 +168,9 @@ val equal : eq:('a -> 'a -> bool) -> 'a array -> 'a array -> bool
     @since 5.4 *)
 
 val compare : cmp:('a -> 'a -> int) -> 'a array -> 'a array -> int
-(** [compare cmp a b] orders [a] and [b] in lexicographic order
-    using [cmp] to compare elements.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/dynarray.mli
+++ b/stdlib/dynarray.mli
@@ -406,10 +406,9 @@ val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 *)
 
 val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
-(** Provided the function [cmp] defines a preorder on elements,
-    [compare cmp a b] compares first [a] and [b] by their length,
-    and then, if equal, by their elements according to
-    the lexicographic preorder.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     For more details on comparison functions, see {!Array.sort}.
 

--- a/stdlib/float.mli
+++ b/stdlib/float.mli
@@ -611,8 +611,9 @@ module Array : sig
       @since 5.4 *)
 
   val compare : (float -> float -> int) -> t -> t -> int
-  (** [compare cmp a b] orders [a] and [b] in lexicographic order
-      using [cmp] to compare elements.
+  (** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+      that is, shorter arrays are smaller and equal-sized arrays are compared
+      in lexicographic order using [cmp] to compare elements.
 
       @since 5.4 *)
 
@@ -993,8 +994,9 @@ module ArrayLabels : sig
       @since 5.4 *)
 
   val compare : cmp:(float -> float -> int) -> t -> t -> int
-  (** [compare cmp a b] orders [a] and [b] in lexicographic order
-      using [cmp] to compare elements.
+  (** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+      that is, shorter arrays are smaller and equal-sized arrays are compared
+      in lexicographic order using [cmp] to compare elements.
 
       @since 5.4 *)
 

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -23,6 +23,11 @@ let get_error = function Error e -> e | Ok _ -> invalid_arg "result is Ok _"
 let bind r f = match r with Ok v -> f v | Error _ as e -> e
 let join = function Ok r -> r | Error _ as e -> e
 let map f = function Ok v -> Ok (f v) | Error _ as e -> e
+let product r0 r1 = match r0, r1 with
+| (Error _ as r), _
+| _, (Error _ as r) -> r
+| Ok v0, Ok v1 -> Ok (v0, v1)
+
 let map_error f = function Error e -> Error (f e) | Ok _ as v -> v
 let fold ~ok ~error = function Ok v -> ok v | Error e -> error e
 let retract = function Ok v -> v | Error v -> v
@@ -45,3 +50,10 @@ let compare ~ok ~error r0 r1 = match r0, r1 with
 let to_option = function Ok v -> Some v | Error _ -> None
 let to_list = function Ok v -> [v] | Error _ -> []
 let to_seq = function Ok v -> Seq.return v | Error _ -> Seq.empty
+
+module Syntax = struct
+  let ( let* ) = bind
+  let ( and* ) = product
+  let ( let+ ) r f = map f r
+  let ( and+ ) = product
+end

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -53,6 +53,12 @@ val join : (('a, 'e) result, 'e) result -> ('a, 'e) result
 val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 (** [map f r] is [Ok (f v)] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 
+val product : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+(** [product r0 r1] is [Ok (v0, v1)] if [r0] is [Ok v0] and [r1] is [Ok v2]
+    and otherwise returns the error of [r0], if any, or the error of [r1].
+
+    @since 5.4 *)
+
 val map_error : ('e -> 'f) -> ('a, 'e) result -> ('a, 'f) result
 (** [map_error f r] is [Error (f e)] if [r] is [Error e] and [r] if
     [r] is [Ok _]. *)
@@ -106,3 +112,23 @@ val to_list : ('a, 'e) result -> 'a list
 val to_seq : ('a, 'e) result -> 'a Seq.t
 (** [to_seq r] is [r] as a sequence. [Ok v] is the singleton sequence
     containing [v] and [Error _] is the empty sequence. *)
+
+(** {1:syntax Syntax} *)
+
+(** Binding operators.
+
+    @since 5.4 *)
+module Syntax : sig
+
+  val ( let* ) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
+  (** [( let* )] is {!Result.bind}. *)
+
+  val ( and* ) : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+  (** [( and* )] is {!Result.product}. *)
+
+  val ( let+ ) : ('a, 'e) result -> ('a -> 'b) -> ('b, 'e) result
+  (** [( let+ )] is {!Result.map}. *)
+
+  val ( and+ ) : ('a, 'e) result -> ('b, 'e) result -> ('a * 'b, 'e) result
+  (** [( and+ )] is {!Result.product}. *)
+end

--- a/stdlib/templates/floatarraylabeled.template.mli
+++ b/stdlib/templates/floatarraylabeled.template.mli
@@ -127,8 +127,9 @@ val equal : eq:(float -> float -> bool) -> t -> t -> bool
     @since 5.4 *)
 
 val compare : cmp:(float -> float -> int) -> t -> t -> int
-(** [compare cmp a b] orders [a] and [b] in lexicographic order
-    using [cmp] to compare elements.
+(** [compare cmp a b] compares [a] and [b] according to the shortlex order,
+    that is, shorter arrays are smaller and equal-sized arrays are compared
+    in lexicographic order using [cmp] to compare elements.
 
     @since 5.4 *)
 

--- a/stdlib/uchar.mli
+++ b/stdlib/uchar.mli
@@ -106,8 +106,9 @@ val hash : t -> int
 (** An unseeded hash function with the same output value as {!Hashtbl.hash}.
     This function allows this module to be passed as an argument to the functor
     {!Hashtbl.Make}.
-
-    @since 5.3 *)
+    @before 5.3 The hashing algorithm was different.
+    Use [Hashtbl.rebuild] for stored tables which used this hashing
+    function *)
 
 (** {1:utf UTF codecs tools}
 

--- a/testsuite/tests/lib-result/test.ml
+++ b/testsuite/tests/lib-result/test.ml
@@ -42,6 +42,13 @@ let test_maps () =
   assert (Result.map_error succ (Ok 2) = Ok 2);
   ()
 
+let test_product () =
+  assert (Result.product (Ok "a") (Ok 3) = Ok ("a", 3));
+  assert (Result.product (Ok "a") (Error "ha") = Error "ha");
+  assert (Result.product (Error "hi") (Error "ha") = Error "hi");
+  assert (Result.product (Error "hi") (Ok 3) = Error "hi");
+  ()
+
 let test_fold () =
   assert (Result.fold ~ok:succ ~error:succ (Ok 1) = 2);
   assert (Result.fold ~ok:succ ~error:succ (Error 1) = 2);
@@ -115,6 +122,23 @@ let test_to_option_list_seq () =
   assert ((Result.to_seq (Error "ha!")) () = Seq.Nil);
   ()
 
+let test_syntax () =
+  let open Result.Syntax in
+  assert (Ok 5 =
+          let parse n = Ok n in
+          let* n0 = parse 3 in
+          let* n1 = parse 2 in
+          Ok (n0 + n1));
+  assert (Ok 3 =
+          let+ one = Ok 1
+          and+ two = Ok 2 in
+          one + two);
+  assert (Ok 1 =
+          let* three = Ok 3 in
+          let+ two = Ok 2 in
+          three - two);
+  ()
+
 let tests () =
   test_ok_error ();
   test_value ();
@@ -122,6 +146,7 @@ let tests () =
   test_bind ();
   test_join ();
   test_maps ();
+  test_product ();
   test_fold ();
   test_retract ();
   test_iters ();
@@ -129,6 +154,7 @@ let tests () =
   test_equal ();
   test_compare ();
   test_to_option_list_seq ();
+  test_syntax ();
   ()
 
 let () =

--- a/testsuite/tests/memory-model/forbidden.ml
+++ b/testsuite/tests/memory-model/forbidden.ml
@@ -1,5 +1,6 @@
 (* TEST
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
+ multicore;
  not-bsd;
  no-tsan; (* tsan detects the intentional data races and fails *)
  {

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -1,5 +1,6 @@
 (* TEST
  modules = "opt.ml barrier.ml hist.ml shared.ml run.ml outcome.ml";
+ multicore;
  no-tsan; (* tsan detects data races and fails *)
  not-bsd;
  {

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -1,5 +1,6 @@
 (* TEST
  include unix;
+ multicore;
  hasunix;
  {
    bytecode;

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -1,4 +1,5 @@
 (* TEST
+ multicore;
  no-tsan; (* TSan detects the intentional data race *)
  {
    bytecode;

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -12,3 +12,27 @@ Line 1, characters 0-39:
 Error: The type abbreviation "T.t" is cyclic:
          "T.t" = "T.t"
 |}]
+
+(* Cyclic module type definitions should throw an error *)
+module rec X : (sig module type A = X.A end)
+  = struct module type A end
+[%%expect {|
+Line 1, characters 36-37:
+1 | module rec X : (sig module type A = X.A end)
+                                        ^
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
+|}]
+
+(* Cyclic module type definitions should throw an error *)
+module rec X : (sig module type A := X.A end)
+  = struct end
+[%%expect {|
+Line 1, characters 37-38:
+1 | module rec X : (sig module type A := X.A end)
+                                         ^
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
+|}]

--- a/testsuite/tests/typing-warnings/unused_types.ml
+++ b/testsuite/tests/typing-warnings/unused_types.ml
@@ -689,3 +689,9 @@ Warning 34 [unused-type-declaration]: unused type alias "'unused2".
 val f : int -> int -> int -> int -> 'used2 -> int * int * int * int * 'used2 =
   <fun>
 |}]
+
+type 'a t = [> `A] as 'a
+
+[%%expect{|
+type 'a t = 'a constraint 'a = [> `A ]
+|}]

--- a/tools/ci/actions/multicoretests.sh
+++ b/tools/ci/actions/multicoretests.sh
@@ -32,7 +32,10 @@ build_ocaml() {
   cd "$OCAMLDIR"
   if ! ./configure --disable-warn-error --disable-stdlib-manpages \
       --disable-ocamltest --disable-ocamldoc --prefix="$PREFIX" ; then
+    echo
+    echo "::group::config.log content ($(wc -l config.log) lines)"
     cat config.log
+    echo '::endgroup::'
     exit 1
   fi
 

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -63,7 +63,7 @@ Build () {
   if [ "$(uname)" = 'Darwin' ]; then
     script -q build.log $MAKE_WARN || failed=$?
     if ((failed)); then
-      script -q build.log $MAKE_WARN make -j1 V=1
+      script -q build.log $MAKE_WARN -j1 V=1
       exit $failed
     fi
   else

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -29,7 +29,12 @@ call-configure () {
   local failed
   ./configure "$@" || failed=$?
   if ((failed)); then
+    # Output seems to be a little unpredictable in GitHub Actions: ensure that
+    # the fold is definitely on a new line
+    echo
+    echo "::group::config.log content ($(wc -l config.log) lines)"
     cat config.log
+    echo '::endgroup::'
     exit $failed
   fi
 }

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -705,28 +705,6 @@ module Merge = struct
     let names = Longident.flatten lid.txt in
     merge_signature ~patch ~destructive initial_env env sg names loc lid
 
-  (* Specialized merge function for package types *)
-  let merge_package_constraint env loc sg lid cty =
-    let patch =
-      patch_all ~destructive:false env loc lid (With_type_package cty) in
-    let _, _, _, sg = merge ~patch ~destructive:false env sg loc lid in
-    sg
-
-  let check_package_with_type_constraints loc env mty constraints =
-    let sg = extract_sig env loc mty in
-    let sg =
-      List.fold_left
-        (fun sg (lid, cty) ->
-           merge_package_constraint env loc sg lid cty)
-        sg constraints
-    in
-    let scope = Ctype.create_scope () in
-    Mtype.freshen ~scope (Mty_signature sg)
-
-  let () =
-    Typetexp.check_package_with_type_constraints :=
-      check_package_with_type_constraints
-
   (* sg with type lid = sdecl *)
   let merge_type ~destructive env loc sg lid sdecl =
     let constr =
@@ -791,6 +769,27 @@ module Merge = struct
     let sg = post_process ~destructive loc lid env paths sg replace in
     path, lid, sg
 
+  (* Specialized merge function for package types *)
+  let merge_package_constraint env loc sg lid cty =
+    let patch =
+      patch_all ~destructive:false env loc lid (With_type_package cty) in
+    let _, _, _, sg = merge ~patch ~destructive:false env sg loc lid in
+    sg
+
+  let check_package_with_type_constraints loc env mty constraints =
+    let sg = extract_sig env loc mty in
+    let sg =
+      List.fold_left
+        (fun sg (lid, cty) ->
+           merge_package_constraint env loc sg lid cty)
+        sg constraints
+    in
+    let scope = Ctype.create_scope () in
+    Mtype.freshen ~scope (Mty_signature sg)
+
+  let () =
+    Typetexp.check_package_with_type_constraints :=
+      check_package_with_type_constraints
 end
 
 (* Add recursion flags on declarations arising from a mutually recursive

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -447,28 +447,27 @@ type merge_constraint =
         remove_aliases:bool
       }
   | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
-  | With_modtype of Typedtree.module_type
-  | With_modtypesubst of Typedtree.module_type
+  | With_modtype of Types.module_type
+  | With_modtypesubst of Types.module_type
 
   (* Package with type constraints only use this last case. *)
   | With_type_package of Typedtree.core_type
 
-  (* Merging of module types during signature approximation *)
-  | Approx_with_modtype      of Types.module_type
-  | Approx_with_modtypesubst of Types.module_type
 
-type merge_result = Path.t * merge_info * Types.signature
-and merge_info =
-  (* Result of normal merging *)
-  | Built_TypedTree of {
-      lid: Longident.t Asttypes.loc ;
-      constr : Typedtree.with_constraint
-    }
-  (* Result of merging a package_type or merging approximated module types
-     (without typedtree) *)
-  | No_TypedTree
+type merge_result = Path.t * (Path.t list)
+                    * (Typedtree.type_declaration option) * Types.signature
 
 module Merge = struct
+
+  (* Helpers *)
+  let return ~ghosts ~replace_by path =
+    Some ((path, [path], None), {Signature_group.ghosts; replace_by})
+
+  let return_payload  ~payload ~ghosts ~replace_by path =
+    Some ((path, [path], payload), {Signature_group.ghosts; replace_by})
+
+  let return_paths  ~payload ~ghosts ~replace_by path paths =
+    Some ((path, paths, payload), {Signature_group.ghosts; replace_by})
 
   let split_row_id s ghosts =
     let srow = s ^ "#row" in
@@ -491,37 +490,45 @@ module Merge = struct
         let error = With_cannot_remove_packed_modtype(p,mty) in
         raise (Error(loc,initial_env,error))
 
-  let merge_constraint_aux initial_env loc sg lid constr : merge_result =
-    let destructive_substitution =
+  (* After the item has been patch, post processing does the actual destructive
+     substitution and checks wellformedness of the resulting signature *)
+  let post_process ~destructive loc lid env paths sg replace =
+    let sg =
+      if destructive then
+        (* Check that the substitution will not make the signature ill-formed *)
+        let _ = check_usage_after_substitution ~loc ~lid env paths sg in
+        (* Actually remove the identifiers *)
+        let sub = Subst.change_locs Subst.identity loc in
+        let sub = List.fold_left replace sub paths in
+        unsafe_signature_subst sub sg loc env
+      else sg
+    in
+    (* check that the resulting signature is still wellformed *)
+    let _ = check_well_formed_module env loc "this instantiated signature"
+        (Mty_signature sg) in
+    sg
+
+  let merge_constraint_aux ?(approx=false) initial_env loc sg lid constr
+    : merge_result =
+    let destructive =
       match constr with
       | With_type _ | With_module _ | With_modtype _
-      | Approx_with_modtype _
       | With_type_package _ -> false
-      | With_typesubst _ | With_modsubst _ | With_modtypesubst _
-      | Approx_with_modtypesubst _ -> true
+      | With_typesubst _ | With_modsubst _ | With_modtypesubst _ -> true
     in
-    let approx_substitution =
-      match constr with
-      | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
-      | _ -> false
-    in
-    let real_ids = ref [] in
     let rec patch_item constr namelist outer_sig_env sg_for_env ~ghosts item =
-      let return ?(ghosts=ghosts) ~replace_by info =
-        Some (info, {Signature_group.ghosts; replace_by})
-      in
       let patch_modtype_item
           id (mtd: Types.modtype_declaration) priv mty  =
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         (* Check for equivalence if the previous module type was not
            empty. During approximation, the equivalence check is ignored. *)
-        let () = match approx_substitution, mtd.mtd_type with
+        let () = match approx, mtd.mtd_type with
           | false, Some previous_mty ->
               Includemod.check_modtype_equiv ~loc sig_env
                 id previous_mty mty
           | _ -> ()
         in
-        if not destructive_substitution then
+        if not destructive then
           let mtd': modtype_declaration =
             {
               mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
@@ -530,11 +537,7 @@ module Merge = struct
               mtd_loc = loc;
             }
           in Some(Sig_modtype(id, mtd', priv))
-        else begin
-          let path = Pident id in
-          real_ids := [path];
-          None
-        end
+        else None
       in
       match item, namelist, constr with
       | Sig_type(id, decl, rs, priv), [s],
@@ -590,9 +593,9 @@ module Merge = struct
             List.rev_append before_ghosts
               (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
           in
-          return ~ghosts
-            ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-            (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
+          let path = Pident id in
+          return_payload ~ghosts ~payload:(Some tdecl)
+            ~replace_by:(Some (Sig_type(id, newdecl, rs, priv))) path
       | Sig_type(id, sig_decl, rs, priv) , [s],
         (With_type sdecl | With_typesubst sdecl)
         when Ident.name id = s ->
@@ -605,17 +608,12 @@ module Merge = struct
           let ghosts = List.rev_append before_ghosts after_ghosts in
           check_type_decl outer_sig_env sg_for_env loc
             id row_id newdecl sig_decl;
-          if not destructive_substitution then
-            return ~ghosts
-              ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-              (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_type tdecl)})
-          else begin
-            real_ids := [Pident id];
-            return ~ghosts ~replace_by:None
-              (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_typesubst tdecl)})
-          end
+          let path = Pident id in
+          let item_opt =
+            if not destructive then (Some(Sig_type(id, newdecl, rs, priv)))
+            else None
+          in
+          return_payload ~ghosts ~payload:(Some tdecl) ~replace_by:item_opt path
       | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
         when Ident.name id = s ->
           begin match sig_decl.type_manifest with
@@ -630,29 +628,19 @@ module Merge = struct
           in
           check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
           let tdecl = { tdecl with type_manifest = None } in
-          return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-            (Pident id, No_TypedTree)
+          let path = Pident id in
+          return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv))) path
       | Sig_modtype(id, mtd, priv), [s],
-        (With_modtype mty | With_modtypesubst mty)
-        when Ident.name id = s ->
-          let new_item = patch_modtype_item id mtd priv mty.mty_type in
-          let constr_tt =
-            if not destructive_substitution then
-              (Twith_modtype mty)
-            else
-              (Twith_modtypesubst mty)
-          in
-          return ~replace_by:new_item
-            (Pident id, Built_TypedTree {lid; constr=constr_tt})
-      | Sig_modtype(id, mtd, priv), [s],
-        (Approx_with_modtype mty | Approx_with_modtypesubst mty)
+        ( With_modtype mty | With_modtypesubst mty)
         when Ident.name id = s ->
           let new_item = patch_modtype_item id mtd priv mty in
-          return ~replace_by:new_item (Pident id, No_TypedTree)
+          let path = Pident id in
+          return ~ghosts ~replace_by:new_item path
       | Sig_module(id, pres, md, rs, priv), [s],
-        With_module {lid=lid'; md=md'; path; remove_aliases}
+        With_module {lid=_; md=md'; path; remove_aliases}
         when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let real_path = Pident id in
           let mty = md'.md_type in
           let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
           let md'' = { md' with md_type = mty } in
@@ -660,127 +648,59 @@ module Merge = struct
               sig_env md'' path in
           ignore(Includemod.modtypes  ~mark:true ~loc sig_env
                    newmd.md_type md.md_type);
-          return
+          return ~ghosts
             ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-            (Pident id, Built_TypedTree {
-                lid=lid; constr=(Twith_module (path, lid'))})
-      | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
+            real_path
+      | Sig_module(id, _, md, _rs, _), [s], With_modsubst (_,path,md')
         when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let real_path = Pident id in
           let aliasable = not (Env.is_functor_arg path sig_env) in
           ignore
             (Includemod.strengthened_module_decl ~loc ~mark:true
                ~aliasable sig_env md' path md);
-          real_ids := [Pident id];
-          return ~replace_by:None
-            (Pident id, Built_TypedTree {
-                lid=lid; constr=(Twith_modsubst (path, lid'))})
+          return ~ghosts ~replace_by:None real_path
 
       (* When the constraint affects a component of a submodule *)
       | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
         when Ident.name id = s ->
           let sig_env = Env.add_signature sg_for_env outer_sig_env in
           let sg = extract_sig sig_env loc md.md_type in
-          let subpath, merge_info, newsg = merge_signature sig_env sg
+          let subpath, paths, payload, newsg = merge_signature sig_env sg
               namelist in
           let path = path_concat id subpath in
-          real_ids := path :: !real_ids ;
-          begin match md.md_type, merge_info with
-          (* A module alias cannot be refined, so keep it
-             and just check that the constraint is correct *)
-          | Mty_alias _, Built_TypedTree
-              { lid; constr = (Twith_module _
-                              | Twith_type _
-                              | Twith_modtype _) as tcstr } ->
-              return ~replace_by:(Some current_item)
-                (path, Built_TypedTree { lid; constr=tcstr} )
-          | _, Built_TypedTree { lid; constr } ->
+          begin match md.md_type, destructive with
+          | Mty_alias _, false ->
+              (* Deep substitutions inside aliases are checked, but do not
+                 change the resulting signature *)
+              return_payload ~ghosts
+                ~replace_by:(Some current_item) path ~payload
+          | _, _ ->
               let new_md = {md with md_type = Mty_signature newsg} in
               let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-              return ~replace_by:(Some new_item)
-                (path, Built_TypedTree {lid; constr})
-          | _, No_TypedTree ->
-              let new_md = {md with md_type = Mty_signature newsg} in
-              let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-              return ~replace_by:(Some new_item) (path, No_TypedTree)
+              return_paths ~ghosts ~replace_by:(Some new_item)
+                path (path::paths) ~payload
           end
       | _ -> None
     and merge_signature env sg namelist =
       match
         Signature_group.replace_in_place (patch_item constr namelist env sg) sg
       with
-      | Some ((path, res), sg) -> path, res, sg
+      | Some ((path, paths, payload), sg) -> path, paths, payload, sg
       | None -> raise(Error(loc, env, With_no_component lid.txt))
     in
     try
       let names = Longident.flatten lid.txt in
-      let (path, merge_info, sg) = merge_signature initial_env sg names in
-      if destructive_substitution then
-        check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
-      let sg =
-        match merge_info, constr with
-        | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
-            let how_to_extend_subst =
-              let sdecl =
-                match constr with
-                | With_typesubst sdecl -> sdecl
-                | _ -> assert false
-              in
-              match type_decl_is_alias sdecl with
-              | Some lid ->
-                  let replacement, _ =
-                    try Env.find_type_by_name lid.txt initial_env
-                    with Not_found -> assert false
-                  in
-                  fun s path -> Subst.Unsafe.add_type_path path replacement s
-              | None ->
-                  let body = Option.get tdecl.typ_type.type_manifest in
-                  let params = tdecl.typ_type.type_params in
-                  if params_are_constrained params
-                  then raise(Error(loc, initial_env,
-                                   With_cannot_remove_constrained_type));
-                  fun s path ->
-                    Subst.Unsafe.add_type_function path ~params ~body s
-            in
-            let sub = Subst.change_locs Subst.identity loc in
-            let sub = List.fold_left how_to_extend_subst sub !real_ids in
-            unsafe_signature_subst sub sg loc initial_env
-        | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
-            let sub = Subst.change_locs Subst.identity loc in
-            let sub =
-              List.fold_left
-                (fun s path -> Subst.Unsafe.add_module_path path real_path s)
-                sub
-                !real_ids
-            in
-            unsafe_signature_subst sub sg loc initial_env
-        | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
-        | _, Approx_with_modtypesubst mty ->
-            let add s p = Subst.Unsafe.add_modtype_path p mty s in
-            let sub = Subst.change_locs Subst.identity loc in
-            let sub = List.fold_left add sub !real_ids in
-            unsafe_signature_subst sub sg loc initial_env
-        | _ ->
-            sg
-      in
-      check_well_formed_module initial_env loc "this instantiated signature"
-        (Mty_signature sg);
-      (path, merge_info, sg)
+      let path, paths, payload, sg = merge_signature initial_env sg names in
+      (path, paths, payload, sg)
     with Includemod.Error explanation ->
       raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-  (* Normal merge function - build the typed tree *)
-  let merge_constraint env loc sg lid cty =
-    match merge_constraint_aux env loc sg lid cty with
-    | path, Built_TypedTree { lid; constr }, newsg ->
-        (path, lid, constr, newsg)
-    | _, No_TypedTree, _ -> assert false
-
   (* Specialized merge function for package types *)
   let merge_package_constraint env loc sg lid cty =
-    match merge_constraint_aux env loc sg lid (With_type_package cty) with
-    | _, No_TypedTree, newsg -> newsg
-    | _, Built_TypedTree _, _ -> assert false
+    let _, _, _, sg =
+      merge_constraint_aux env loc sg lid (With_type_package cty) in
+    sg
 
   let check_package_with_type_constraints loc env mty constraints =
     let sg = extract_sig env loc mty in
@@ -797,17 +717,67 @@ module Merge = struct
     Typetexp.check_package_with_type_constraints :=
       check_package_with_type_constraints
 
-  (* Specialized merge function for merging during signature approximation *)
-  let merge_constraint_approx env loc sg lid mty ~destructive =
+  (* sg with type lid = sdecl *)
+  let merge_type ~destructive env loc sg lid sdecl =
     let constr =
       if not destructive then
-        Approx_with_modtype mty
+        With_type sdecl
       else
-        Approx_with_modtypesubst mty
+        With_typesubst sdecl
     in
-    match merge_constraint_aux env loc sg lid constr with
-    | _, No_TypedTree, newsg -> newsg
-    | _, Built_TypedTree _, _ -> assert false
+    match (merge_constraint_aux env loc sg lid constr) with
+    | path, paths, Some tdecl, sg -> begin
+        let replace =
+          match type_decl_is_alias sdecl with
+          | Some lid ->
+              (* if the type is an alias of [lid], replace by the definition *)
+              let replacement, _ =
+                try Env.find_type_by_name lid.txt env
+                with Not_found -> assert false
+              in
+              fun s path -> Subst.Unsafe.add_type_path path replacement s
+          | None ->
+              (* if the type is not an alias, try to inline it *)
+              let body = Option.get tdecl.typ_type.type_manifest in
+              let params = tdecl.typ_type.type_params in
+              if params_are_constrained params then
+                raise(Error(loc, env, With_cannot_remove_constrained_type));
+              fun s path ->
+                Subst.Unsafe.add_type_function path ~params ~body s
+        in
+        let sg = post_process ~destructive loc lid env paths sg replace in
+        tdecl, (path, lid, sg)
+      end
+    | _ -> assert false
+
+  (* [sg with module lid = path] *)
+  (* md' is the module type of the module at [path], used for equiv checks *)
+  let merge_module ~destructive env loc sg lid
+      (md': Types.module_declaration) path remove_aliases =
+    let constr =
+      if not destructive then
+        With_module {lid; path; md=md'; remove_aliases}
+      else
+        With_modsubst (lid, path, md')
+    in
+    let real_path,paths,_,sg = (merge_constraint_aux env loc sg lid constr) in
+    let replace s p = Subst.Unsafe.add_module_path p path s in
+    let sg = post_process ~destructive loc lid env paths sg replace in
+    real_path, lid, sg
+
+  (* [sg with module type lid = mty] *)
+  let merge_modtype ?(approx=false) ~destructive env loc sg lid mty =
+    let constr =
+      if not destructive then
+        With_modtype mty
+      else
+        With_modtypesubst mty
+    in
+    let path,paths,_,sg =
+      (merge_constraint_aux ~approx env loc sg lid constr) in
+    let replace s p = Subst.Unsafe.add_modtype_path p mty s in
+    let sg = post_process ~destructive loc lid env paths sg replace in
+    path, lid, sg
 
 end
 
@@ -1039,8 +1009,9 @@ and approx_constraint env body constr =
       let destructive =
         (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      Merge.merge_constraint_approx ~destructive
-        env smty.pmty_loc body id approx_smty
+      let _ ,_,sg = Merge.merge_modtype ~destructive ~approx:true
+          env smty.pmty_loc body id approx_smty in
+      sg
   (* module substitutions are ignored, but checked for cyclicity *)
   | Pwith_module (_, lid') ->
       (* Lookup the module to make sure that it is not recursive.
@@ -1441,25 +1412,47 @@ and transl_modtype_aux env smty =
   | Pmty_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
-and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
-  let lid, with_info = match constr with
-    | Pwith_type (l,decl) ->l , With_type decl
-    | Pwith_typesubst (l,decl) ->l , With_typesubst decl
-    | Pwith_module (l,l') ->
-        let path, md = Env.lookup_module ~loc l'.txt env in
-        l , With_module {lid=l';path;md; remove_aliases}
-    | Pwith_modsubst (l,l') ->
-        let path, md' = Env.lookup_module ~loc l'.txt env in
-        l , With_modsubst (l',path,md')
-    | Pwith_modtype (l,smty) ->
-        let mty = transl_modtype env smty in
-        l, With_modtype mty
-    | Pwith_modtypesubst (l,smty) ->
-        let mty = transl_modtype env smty in
-        l, With_modtypesubst mty
+
+and transl_with ~loc env remove_aliases (rev_tcstrs, sg) constr =
+  let destructive = match constr with
+    | Pwith_typesubst _ | Pwith_modsubst _ | Pwith_modtypesubst _ -> true
+    | _ -> false
   in
-  let (path, lid, constr, sg) =
-    Merge.merge_constraint env loc sg lid with_info in
+  let constr, (path, lid, sg) = match constr with
+    | Pwith_type (l, decl)
+    | Pwith_typesubst (l, decl) ->
+        let tdecl, merge_res =
+          Merge.merge_type ~destructive env loc sg l decl
+        in
+        let constr = if destructive then
+            (Twith_typesubst tdecl)
+          else
+            (Twith_type tdecl)
+        in
+        (constr, merge_res)
+
+    | Pwith_module (l, l')
+    | Pwith_modsubst (l,l') ->
+        let path, md = Env.lookup_module ~loc l'.txt env in
+        let constr = if destructive then
+            (Twith_modsubst (path, l'))
+          else
+            (Twith_module (path, l'))
+        in
+        (constr,
+         Merge.merge_module ~destructive env loc sg l md path remove_aliases)
+
+    | Pwith_modtype (l,smty)
+    | Pwith_modtypesubst (l,smty) ->
+        let tmty = transl_modtype env smty in
+        let constr = if destructive then
+            (Twith_modtypesubst tmty)
+          else
+            (Twith_modtype tmty)
+        in
+        (constr, Merge.merge_modtype ~destructive env loc sg l tmty.mty_type)
+
+  in
   ((path, lid, constr) :: rev_tcstrs, sg)
 
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -436,8 +436,48 @@ let params_are_constrained =
   in
   loop
 
-
 module Merge = struct
+  (* This module hosts the functions dealing with signature constraints. There
+     are of three forms :
+     - type constraint [... with type t = ... ], handled by [merge_type]
+     - module constraint [... with module X = ... ], handled by [merge_module]
+     - module type constraints [... with module type T = ...] handled by
+       [merge_modtype]
+
+     Each constraint can be *destructive*, (with the syntax [:=]) meaning that
+     the substituted identifier is removed from the signature. This imposes
+     additional checks to ensure wellformedness, handled by the [post_process]
+     function.
+
+     Each constraint can be *deep*, meaning that the substituted identifier
+     might be inside a submodule. This is handled by the [patch_deep_item]
+     function. Deep destructive substitutions inside submodules with an alias
+     signature are disallowed.
+
+     Each constraint can be *instantiating*, if the substitution replaces an
+     "abstract" field (for module constraints, "abstract" means "not already an
+     alias"). If the constraint is not instantiating, equivalence checks with
+     the old definition are performed.
+
+     Finally, merging is both used in (1) "normal" mode, to build a typed tree,
+     in (2) "approx" mode, during the signature approximation phase of
+     typechecking recursive modules, and in (3) "package" mode, for checking
+     signatures of first-class modules.
+
+     The overall structure is similar for each form:
+
+     1. A [patch] function is defined to identify the item to substitute, do the
+     equivalence checks if needed, and optionally build the new replacement item
+     (if the substitution is non-destructive)
+
+     2. The patch is applied to the module type by using the general
+     [merge_signature] function. It returns the path of the affected item (along
+     with the list of all suffixes, if the substitution was deep).
+
+     3. Some post processing is applied (actual replacement for destructive
+     substitutions, wellformedness checks)
+
+  *)
 
   (* Helpers *)
   let return ~ghosts ~replace_by path =
@@ -491,18 +531,13 @@ module Merge = struct
   (* Main recursive knot to handle deep merges *)
   let rec merge_signature initial_env env sg namelist loc lid
       ~patch ~destructive =
-    try
-      begin
-        match
-          Signature_group.replace_in_place
-            (patch_deep_item ~patch ~destructive
-               namelist initial_env env sg loc lid) sg
-        with
-        | Some ((p, paths, payload), sg) -> p, paths, payload, sg
-        | None -> raise(Error(loc, initial_env, With_no_component lid.txt))
-      end
-    with Includemod.Error explanation ->
-      raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
+    match
+      Signature_group.replace_in_place
+        (patch_deep_item ~patch ~destructive
+           namelist initial_env env sg loc lid) sg
+    with
+    | Some ((p, paths, payload), sg) -> p, paths, payload, sg
+    | None -> raise(Error(loc, initial_env, With_no_component lid.txt))
 
   and patch_deep_item ~ghosts ~patch ~destructive
       namelist initial_env (env: Env.t) outer_sg loc lid item =
@@ -538,7 +573,10 @@ module Merge = struct
   let merge ~patch ~destructive env sg loc lid =
     let initial_env = env in
     let names = Longident.flatten lid.txt in
-    merge_signature ~patch ~destructive initial_env env sg names loc lid
+    try
+      merge_signature ~patch ~destructive initial_env env sg names loc lid
+    with Includemod.Error explanation ->
+      raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
   (* sg with type lid = sdecl *)
   let merge_type ~destructive env loc sg lid sdecl =
@@ -714,8 +752,8 @@ module Merge = struct
     let sg = post_process ~destructive loc lid env paths sg replace in
     path, lid, sg
 
-  (* Specialized merge function for package types *)
-  let merge_package_constraint env loc sg lid cty =
+  (* sg with type lid = cty (inside a first class module type) *)
+  let merge_package env loc sg lid cty =
     let patch item s sig_env sg_for_env ~ghosts = match item with
       | Sig_type(id, sig_decl, rs, priv)
         when Ident.name id = s ->
@@ -741,7 +779,7 @@ module Merge = struct
     let sg =
       List.fold_left
         (fun sg (lid, cty) ->
-           merge_package_constraint env loc sg lid cty)
+           merge_package env loc sg lid cty)
         sg constraints
     in
     let scope = Ctype.create_scope () in
@@ -980,7 +1018,7 @@ and approx_constraint env body constr =
       let destructive =
         (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      let _ ,_,sg = Merge.merge_modtype ~destructive ~approx:true
+      let _,_,sg = Merge.merge_modtype ~approx:true ~destructive
           env smty.pmty_loc body id approx_smty in
       sg
   (* module substitutions are ignored, but checked for cyclicity *)
@@ -1382,7 +1420,6 @@ and transl_modtype_aux env smty =
       mkmty (Tmty_typeof tmty) mty env loc smty.pmty_attributes
   | Pmty_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
-
 
 and transl_with ~loc env remove_aliases (rev_tcstrs, sg) constr =
   let destructive = match constr with

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -468,340 +468,348 @@ and merge_info =
      (without typedtree) *)
   | No_TypedTree
 
-let merge_constraint_aux initial_env loc sg lid constr : merge_result =
-  let destructive_substitution =
-    match constr with
-    | With_type _ | With_module _ | With_modtype _
-    | Approx_with_modtype _
-    | With_type_package _ -> false
-    | With_typesubst _ | With_modsubst _ | With_modtypesubst _
-    | Approx_with_modtypesubst _ -> true
-  in
-  let approx_substitution =
-    match constr with
-    | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
-    | _ -> false
-  in
-  let real_ids = ref [] in
-  let split_row_id s ghosts =
-    let srow = s ^ "#row" in
-    let rec split before = function
+module Merge = struct
+
+  let merge_constraint_aux initial_env loc sg lid constr : merge_result =
+    let destructive_substitution =
+      match constr with
+      | With_type _ | With_module _ | With_modtype _
+      | Approx_with_modtype _
+      | With_type_package _ -> false
+      | With_typesubst _ | With_modsubst _ | With_modtypesubst _
+      | Approx_with_modtypesubst _ -> true
+    in
+    let approx_substitution =
+      match constr with
+      | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
+      | _ -> false
+    in
+    let real_ids = ref [] in
+    let split_row_id s ghosts =
+      let srow = s ^ "#row" in
+      let rec split before = function
         | Sig_type(id,_,_,_) :: rest when Ident.name id = srow ->
             before, Some id, rest
         | a :: rest -> split (a::before) rest
         | [] -> before, None, []
-    in
-    split [] ghosts
-  in
-  let unsafe_signature_subst sub sg =
-    (* This signature will not be used directly, it will always be freshened
-       by the caller. So what we do with the scope doesn't really matter. But
-       making it local makes it unlikely that we will ever use the result of
-       this function unfreshened without issue. *)
-    match Subst.Unsafe.signature Make_local sub sg with
-    | Ok x -> x
-    | Error (Fcm_type_substituted_away (p,mty)) ->
-        let error = With_cannot_remove_packed_modtype(p,mty) in
-        raise (Error(loc,initial_env,error))
-  in
-  let rec patch_item constr namelist outer_sig_env sg_for_env ~ghosts item =
-    let return ?(ghosts=ghosts) ~replace_by info =
-      Some (info, {Signature_group.ghosts; replace_by})
-    in
-    let patch_modtype_item
-        id (mtd: Types.modtype_declaration) priv mty  =
-      let sig_env = Env.add_signature sg_for_env outer_sig_env in
-      (* Check for equivalence if the previous module type was not empty. During
-         approximation, the equivalence check is ignored. *)
-      let () = match approx_substitution, mtd.mtd_type with
-        | false, Some previous_mty ->
-            Includemod.check_modtype_equiv ~loc sig_env
-              id previous_mty mty
-        | _ -> ()
       in
-      if not destructive_substitution then
-        let mtd': modtype_declaration =
-          {
-            mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-            mtd_type = Some mty;
-            mtd_attributes = [];
-            mtd_loc = loc;
-          }
-        in Some(Sig_modtype(id, mtd', priv))
-      else begin
-        let path = Pident id in
-        real_ids := [path];
-        None
-      end
+      split [] ghosts
     in
-    match item, namelist, constr with
-    | Sig_type(id, decl, rs, priv), [s],
-       With_type ({ptype_kind = Ptype_abstract} as sdecl)
-      when Ident.name id = s && Typedecl.is_fixed_type sdecl ->
-        let decl_row =
-          let arity = List.length sdecl.ptype_params in
-          {
-            type_params =
-              List.map (fun _ -> Btype.newgenvar()) sdecl.ptype_params;
-            type_arity = arity;
-            type_kind = Type_abstract Definition;
-            type_private = Private;
-            type_manifest = None;
-            type_variance =
-              List.map
-                (fun (_, (v, i)) ->
-                   let (c, n) =
-                     match v with
-                     | Covariant -> true, false
-                     | Contravariant -> false, true
-                     | NoVariance -> false, false
-                     | Bivariant -> true, true
-                   in
-                   make_variance (not n) (not c) (i = Injective)
-                )
-                sdecl.ptype_params;
-            type_separability =
-              Types.Separability.default_signature ~arity;
-            type_loc = sdecl.ptype_loc;
-            type_is_newtype = false;
-            type_expansion_scope = Btype.lowest_level;
-            type_attributes = [];
-            type_immediate = Unknown;
-            type_unboxed_default = false;
-            type_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
-          }
-        and id_row = Ident.create_local (s^"#row") in
-        let initial_env =
-          Env.add_type ~check:false id_row decl_row initial_env
-        in
+    let unsafe_signature_subst sub sg =
+      (* This signature will not be used directly, it will always be freshened
+         by the caller. So what we do with the scope doesn't really matter. But
+         making it local makes it unlikely that we will ever use the result of
+         this function unfreshened without issue. *)
+      match Subst.Unsafe.signature Make_local sub sg with
+      | Ok x -> x
+      | Error (Fcm_type_substituted_away (p,mty)) ->
+          let error = With_cannot_remove_packed_modtype(p,mty) in
+          raise (Error(loc,initial_env,error))
+    in
+    let rec patch_item constr namelist outer_sig_env sg_for_env ~ghosts item =
+      let return ?(ghosts=ghosts) ~replace_by info =
+        Some (info, {Signature_group.ghosts; replace_by})
+      in
+      let patch_modtype_item
+          id (mtd: Types.modtype_declaration) priv mty  =
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let tdecl =
-          Typedecl.transl_with_constraint id ~fixed_row_path:(Pident id_row)
-            ~sig_env ~sig_decl:decl ~outer_env:initial_env sdecl in
-        let newdecl = tdecl.typ_type in
-        let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
-        check_type_decl outer_sig_env sg_for_env sdecl.ptype_loc
-          id row_id newdecl decl;
-        let decl_row = {decl_row with type_params = newdecl.type_params} in
-        let rs' = if rs = Trec_first then Trec_not else rs in
-        let ghosts =
-          List.rev_append before_ghosts
-            (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
+        (* Check for equivalence if the previous module type was not
+           empty. During approximation, the equivalence check is ignored. *)
+        let () = match approx_substitution, mtd.mtd_type with
+          | false, Some previous_mty ->
+              Includemod.check_modtype_equiv ~loc sig_env
+                id previous_mty mty
+          | _ -> ()
         in
-        return ~ghosts
-          ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-          (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
-    | Sig_type(id, sig_decl, rs, priv) , [s],
-       (With_type sdecl | With_typesubst sdecl)
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let tdecl =
-          Typedecl.transl_with_constraint id
-            ~sig_env ~sig_decl ~outer_env:initial_env sdecl in
-        let newdecl = tdecl.typ_type and loc = sdecl.ptype_loc in
-        let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
-        let ghosts = List.rev_append before_ghosts after_ghosts in
-        check_type_decl outer_sig_env sg_for_env loc
-          id row_id newdecl sig_decl;
         if not destructive_substitution then
-          return ~ghosts
-            ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-            (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_type tdecl)})
+          let mtd': modtype_declaration =
+            {
+              mtd_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+              mtd_type = Some mty;
+              mtd_attributes = [];
+              mtd_loc = loc;
+            }
+          in Some(Sig_modtype(id, mtd', priv))
         else begin
-          real_ids := [Pident id];
-          return ~ghosts ~replace_by:None
-            (Pident id, Built_TypedTree {
-                  lid=lid; constr=(Twith_typesubst tdecl)})
+          let path = Pident id in
+          real_ids := [path];
+          None
         end
-    | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
-      when Ident.name id = s ->
-        begin match sig_decl.type_manifest with
-        | None -> ()
-        | Some ty ->
-          raise (Error(loc, outer_sig_env, With_package_manifest (lid.txt, ty)))
-        end;
-        Env.mark_type_used sig_decl.type_uid;
-        let tdecl =
-          Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
-        in
-        check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
-        let tdecl = { tdecl with type_manifest = None } in
-        return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-          (Pident id, No_TypedTree)
-    | Sig_modtype(id, mtd, priv), [s],
-      (With_modtype mty | With_modtypesubst mty)
-      when Ident.name id = s ->
-        let new_item = patch_modtype_item id mtd priv mty.mty_type in
-        let constr_tt =
+      in
+      match item, namelist, constr with
+      | Sig_type(id, decl, rs, priv), [s],
+        With_type ({ptype_kind = Ptype_abstract} as sdecl)
+        when Ident.name id = s && Typedecl.is_fixed_type sdecl ->
+          let decl_row =
+            let arity = List.length sdecl.ptype_params in
+            {
+              type_params =
+                List.map (fun _ -> Btype.newgenvar()) sdecl.ptype_params;
+              type_arity = arity;
+              type_kind = Type_abstract Definition;
+              type_private = Private;
+              type_manifest = None;
+              type_variance =
+                List.map
+                  (fun (_, (v, i)) ->
+                     let (c, n) =
+                       match v with
+                       | Covariant -> true, false
+                       | Contravariant -> false, true
+                       | NoVariance -> false, false
+                       | Bivariant -> true, true
+                     in
+                     make_variance (not n) (not c) (i = Injective)
+                  )
+                  sdecl.ptype_params;
+              type_separability =
+                Types.Separability.default_signature ~arity;
+              type_loc = sdecl.ptype_loc;
+              type_is_newtype = false;
+              type_expansion_scope = Btype.lowest_level;
+              type_attributes = [];
+              type_immediate = Unknown;
+              type_unboxed_default = false;
+              type_uid = Uid.mk ~current_unit:(Env.get_current_unit ());
+            }
+          and id_row = Ident.create_local (s^"#row") in
+          let initial_env =
+            Env.add_type ~check:false id_row decl_row initial_env
+          in
+          let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let tdecl =
+            Typedecl.transl_with_constraint id ~fixed_row_path:(Pident id_row)
+              ~sig_env ~sig_decl:decl ~outer_env:initial_env sdecl in
+          let newdecl = tdecl.typ_type in
+          let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
+          check_type_decl outer_sig_env sg_for_env sdecl.ptype_loc
+            id row_id newdecl decl;
+          let decl_row = {decl_row with type_params = newdecl.type_params} in
+          let rs' = if rs = Trec_first then Trec_not else rs in
+          let ghosts =
+            List.rev_append before_ghosts
+              (Sig_type(id_row, decl_row, rs', priv)::after_ghosts)
+          in
+          return ~ghosts
+            ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
+            (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
+      | Sig_type(id, sig_decl, rs, priv) , [s],
+        (With_type sdecl | With_typesubst sdecl)
+        when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let tdecl =
+            Typedecl.transl_with_constraint id
+              ~sig_env ~sig_decl ~outer_env:initial_env sdecl in
+          let newdecl = tdecl.typ_type and loc = sdecl.ptype_loc in
+          let before_ghosts, row_id, after_ghosts = split_row_id s ghosts in
+          let ghosts = List.rev_append before_ghosts after_ghosts in
+          check_type_decl outer_sig_env sg_for_env loc
+            id row_id newdecl sig_decl;
           if not destructive_substitution then
-            (Twith_modtype mty)
-          else
-            (Twith_modtypesubst mty)
-        in
-        return ~replace_by:new_item
-          (Pident id, Built_TypedTree {lid; constr=constr_tt})
-    | Sig_modtype(id, mtd, priv), [s],
-      (Approx_with_modtype mty | Approx_with_modtypesubst mty)
-      when Ident.name id = s ->
-        let new_item = patch_modtype_item id mtd priv mty in
-        return ~replace_by:new_item (Pident id, No_TypedTree)
-    | Sig_module(id, pres, md, rs, priv), [s],
-      With_module {lid=lid'; md=md'; path; remove_aliases}
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let mty = md'.md_type in
-        let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
-        let md'' = { md' with md_type = mty } in
-        let newmd = Mtype.strengthen_decl ~aliasable:false sig_env md'' path in
-        ignore(Includemod.modtypes  ~mark:true ~loc sig_env
-                 newmd.md_type md.md_type);
-        return
-          ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-          (Pident id, Built_TypedTree {
-              lid=lid; constr=(Twith_module (path, lid'))})
-    | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let aliasable = not (Env.is_functor_arg path sig_env) in
-        ignore
-          (Includemod.strengthened_module_decl ~loc ~mark:true
-             ~aliasable sig_env md' path md);
-        real_ids := [Pident id];
-        return ~replace_by:None
-          (Pident id, Built_TypedTree {
-               lid=lid; constr=(Twith_modsubst (path, lid'))})
+            return ~ghosts
+              ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
+              (Pident id, Built_TypedTree {
+                  lid=lid; constr=(Twith_type tdecl)})
+          else begin
+            real_ids := [Pident id];
+            return ~ghosts ~replace_by:None
+              (Pident id, Built_TypedTree {
+                  lid=lid; constr=(Twith_typesubst tdecl)})
+          end
+      | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
+        when Ident.name id = s ->
+          begin match sig_decl.type_manifest with
+          | None -> ()
+          | Some ty ->
+              raise (Error(loc, outer_sig_env,
+                           With_package_manifest (lid.txt, ty)))
+          end;
+          Env.mark_type_used sig_decl.type_uid;
+          let tdecl =
+            Typedecl.transl_package_constraint ~loc outer_sig_env cty.ctyp_type
+          in
+          check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
+          let tdecl = { tdecl with type_manifest = None } in
+          return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
+            (Pident id, No_TypedTree)
+      | Sig_modtype(id, mtd, priv), [s],
+        (With_modtype mty | With_modtypesubst mty)
+        when Ident.name id = s ->
+          let new_item = patch_modtype_item id mtd priv mty.mty_type in
+          let constr_tt =
+            if not destructive_substitution then
+              (Twith_modtype mty)
+            else
+              (Twith_modtypesubst mty)
+          in
+          return ~replace_by:new_item
+            (Pident id, Built_TypedTree {lid; constr=constr_tt})
+      | Sig_modtype(id, mtd, priv), [s],
+        (Approx_with_modtype mty | Approx_with_modtypesubst mty)
+        when Ident.name id = s ->
+          let new_item = patch_modtype_item id mtd priv mty in
+          return ~replace_by:new_item (Pident id, No_TypedTree)
+      | Sig_module(id, pres, md, rs, priv), [s],
+        With_module {lid=lid'; md=md'; path; remove_aliases}
+        when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let mty = md'.md_type in
+          let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
+          let md'' = { md' with md_type = mty } in
+          let newmd = Mtype.strengthen_decl ~aliasable:false
+              sig_env md'' path in
+          ignore(Includemod.modtypes  ~mark:true ~loc sig_env
+                   newmd.md_type md.md_type);
+          return
+            ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
+            (Pident id, Built_TypedTree {
+                lid=lid; constr=(Twith_module (path, lid'))})
+      | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
+        when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let aliasable = not (Env.is_functor_arg path sig_env) in
+          ignore
+            (Includemod.strengthened_module_decl ~loc ~mark:true
+               ~aliasable sig_env md' path md);
+          real_ids := [Pident id];
+          return ~replace_by:None
+            (Pident id, Built_TypedTree {
+                lid=lid; constr=(Twith_modsubst (path, lid'))})
 
-    (* When the constraint affects a component of a submodule *)
-    | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
-      when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let sg = extract_sig sig_env loc md.md_type in
-        let subpath, merge_info, newsg = merge_signature sig_env sg namelist in
-        let path = path_concat id subpath in
-        real_ids := path :: !real_ids ;
-        begin match md.md_type, merge_info with
-        (* A module alias cannot be refined, so keep it
-           and just check that the constraint is correct *)
-        | Mty_alias _, Built_TypedTree
-            { lid; constr = (Twith_module _
-                            | Twith_type _
-                            | Twith_modtype _) as tcstr } ->
-            return ~replace_by:(Some current_item)
-              (path, Built_TypedTree { lid; constr=tcstr} )
-        | _, Built_TypedTree { lid; constr } ->
-            let new_md = {md with md_type = Mty_signature newsg} in
-            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-            return ~replace_by:(Some new_item)
-              (path, Built_TypedTree {lid; constr})
-        | _, No_TypedTree ->
-            let new_md = {md with md_type = Mty_signature newsg} in
-            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
-            return ~replace_by:(Some new_item) (path, No_TypedTree)
-        end
-    | _ -> None
-  and merge_signature env sg namelist =
-    match
-      Signature_group.replace_in_place (patch_item constr namelist env sg) sg
-    with
-    | Some ((path, res), sg) -> path, res, sg
-    | None -> raise(Error(loc, env, With_no_component lid.txt))
-  in
-  try
-    let names = Longident.flatten lid.txt in
-    let (path, merge_info, sg) = merge_signature initial_env sg names in
-    if destructive_substitution then
-      check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
-    let sg =
-    match merge_info, constr with
-      | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
-       let how_to_extend_subst =
-         let sdecl =
-           match constr with
-           | With_typesubst sdecl -> sdecl
-           | _ -> assert false
-         in
-         match type_decl_is_alias sdecl with
-         | Some lid ->
-            let replacement, _ =
-              try Env.find_type_by_name lid.txt initial_env
-              with Not_found -> assert false
-            in
-            fun s path -> Subst.Unsafe.add_type_path path replacement s
-         | None ->
-            let body = Option.get tdecl.typ_type.type_manifest in
-            let params = tdecl.typ_type.type_params in
-            if params_are_constrained params
-            then raise(Error(loc, initial_env,
-                             With_cannot_remove_constrained_type));
-            fun s path -> Subst.Unsafe.add_type_function path ~params ~body s
-       in
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub = List.fold_left how_to_extend_subst sub !real_ids in
-       unsafe_signature_subst sub sg
-    | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
-       let sub = Subst.change_locs Subst.identity loc in
-       let sub =
-         List.fold_left
-           (fun s path -> Subst.Unsafe.add_module_path path real_path s)
-           sub
-           !real_ids
-       in
-       unsafe_signature_subst sub sg
-    | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
-    | _, Approx_with_modtypesubst mty ->
-        let add s p = Subst.Unsafe.add_modtype_path p mty s in
-        let sub = Subst.change_locs Subst.identity loc in
-        let sub = List.fold_left add sub !real_ids in
-        unsafe_signature_subst sub sg
-    | _ ->
-       sg
+      (* When the constraint affects a component of a submodule *)
+      | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
+        when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env outer_sig_env in
+          let sg = extract_sig sig_env loc md.md_type in
+          let subpath, merge_info, newsg = merge_signature sig_env sg
+              namelist in
+          let path = path_concat id subpath in
+          real_ids := path :: !real_ids ;
+          begin match md.md_type, merge_info with
+          (* A module alias cannot be refined, so keep it
+             and just check that the constraint is correct *)
+          | Mty_alias _, Built_TypedTree
+              { lid; constr = (Twith_module _
+                              | Twith_type _
+                              | Twith_modtype _) as tcstr } ->
+              return ~replace_by:(Some current_item)
+                (path, Built_TypedTree { lid; constr=tcstr} )
+          | _, Built_TypedTree { lid; constr } ->
+              let new_md = {md with md_type = Mty_signature newsg} in
+              let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+              return ~replace_by:(Some new_item)
+                (path, Built_TypedTree {lid; constr})
+          | _, No_TypedTree ->
+              let new_md = {md with md_type = Mty_signature newsg} in
+              let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+              return ~replace_by:(Some new_item) (path, No_TypedTree)
+          end
+      | _ -> None
+    and merge_signature env sg namelist =
+      match
+        Signature_group.replace_in_place (patch_item constr namelist env sg) sg
+      with
+      | Some ((path, res), sg) -> path, res, sg
+      | None -> raise(Error(loc, env, With_no_component lid.txt))
     in
-    check_well_formed_module initial_env loc "this instantiated signature"
-      (Mty_signature sg);
-    (path, merge_info, sg)
-  with Includemod.Error explanation ->
-    raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
+    try
+      let names = Longident.flatten lid.txt in
+      let (path, merge_info, sg) = merge_signature initial_env sg names in
+      if destructive_substitution then
+        check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
+      let sg =
+        match merge_info, constr with
+        | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
+            let how_to_extend_subst =
+              let sdecl =
+                match constr with
+                | With_typesubst sdecl -> sdecl
+                | _ -> assert false
+              in
+              match type_decl_is_alias sdecl with
+              | Some lid ->
+                  let replacement, _ =
+                    try Env.find_type_by_name lid.txt initial_env
+                    with Not_found -> assert false
+                  in
+                  fun s path -> Subst.Unsafe.add_type_path path replacement s
+              | None ->
+                  let body = Option.get tdecl.typ_type.type_manifest in
+                  let params = tdecl.typ_type.type_params in
+                  if params_are_constrained params
+                  then raise(Error(loc, initial_env,
+                                   With_cannot_remove_constrained_type));
+                  fun s path ->
+                    Subst.Unsafe.add_type_function path ~params ~body s
+            in
+            let sub = Subst.change_locs Subst.identity loc in
+            let sub = List.fold_left how_to_extend_subst sub !real_ids in
+            unsafe_signature_subst sub sg
+        | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
+            let sub = Subst.change_locs Subst.identity loc in
+            let sub =
+              List.fold_left
+                (fun s path -> Subst.Unsafe.add_module_path path real_path s)
+                sub
+                !real_ids
+            in
+            unsafe_signature_subst sub sg
+        | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
+        | _, Approx_with_modtypesubst mty ->
+            let add s p = Subst.Unsafe.add_modtype_path p mty s in
+            let sub = Subst.change_locs Subst.identity loc in
+            let sub = List.fold_left add sub !real_ids in
+            unsafe_signature_subst sub sg
+        | _ ->
+            sg
+      in
+      check_well_formed_module initial_env loc "this instantiated signature"
+        (Mty_signature sg);
+      (path, merge_info, sg)
+    with Includemod.Error explanation ->
+      raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-(* Normal merge function - build the typed tree *)
-let merge_constraint env loc sg lid cty =
-  match merge_constraint_aux env loc sg lid cty with
-  | path, Built_TypedTree { lid; constr }, newsg ->
-      (path, lid, constr, newsg)
-  | _, No_TypedTree, _ -> assert false
+  (* Normal merge function - build the typed tree *)
+  let merge_constraint env loc sg lid cty =
+    match merge_constraint_aux env loc sg lid cty with
+    | path, Built_TypedTree { lid; constr }, newsg ->
+        (path, lid, constr, newsg)
+    | _, No_TypedTree, _ -> assert false
 
-(* Specialized merge function for package types *)
-let merge_package_constraint env loc sg lid cty =
-  match merge_constraint_aux env loc sg lid (With_type_package cty) with
-  | _, No_TypedTree, newsg -> newsg
-  | _, Built_TypedTree _, _ -> assert false
+  (* Specialized merge function for package types *)
+  let merge_package_constraint env loc sg lid cty =
+    match merge_constraint_aux env loc sg lid (With_type_package cty) with
+    | _, No_TypedTree, newsg -> newsg
+    | _, Built_TypedTree _, _ -> assert false
 
-let check_package_with_type_constraints loc env mty constraints =
-  let sg = extract_sig env loc mty in
-  let sg =
-    List.fold_left
-      (fun sg (lid, cty) ->
-         merge_package_constraint env loc sg lid cty)
-      sg constraints
-  in
-  let scope = Ctype.create_scope () in
-  Mtype.freshen ~scope (Mty_signature sg)
+  let check_package_with_type_constraints loc env mty constraints =
+    let sg = extract_sig env loc mty in
+    let sg =
+      List.fold_left
+        (fun sg (lid, cty) ->
+           merge_package_constraint env loc sg lid cty)
+        sg constraints
+    in
+    let scope = Ctype.create_scope () in
+    Mtype.freshen ~scope (Mty_signature sg)
 
-let () =
-  Typetexp.check_package_with_type_constraints :=
-    check_package_with_type_constraints
+  let () =
+    Typetexp.check_package_with_type_constraints :=
+      check_package_with_type_constraints
 
-(* Specialized merge function for merging during signature approximation *)
-let merge_constraint_approx env loc sg lid mty ~destructive =
-  let constr =
-    if not destructive then
-      Approx_with_modtype mty
-    else
-      Approx_with_modtypesubst mty
-  in
-  match merge_constraint_aux env loc sg lid constr with
-  | _, No_TypedTree, newsg -> newsg
-  | _, Built_TypedTree _, _ -> assert false
+  (* Specialized merge function for merging during signature approximation *)
+  let merge_constraint_approx env loc sg lid mty ~destructive =
+    let constr =
+      if not destructive then
+        Approx_with_modtype mty
+      else
+        Approx_with_modtypesubst mty
+    in
+    match merge_constraint_aux env loc sg lid constr with
+    | _, No_TypedTree, newsg -> newsg
+    | _, Built_TypedTree _, _ -> assert false
+
+end
 
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)
@@ -1031,7 +1039,7 @@ and approx_constraint env body constr =
       let destructive =
         (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
-      merge_constraint_approx ~destructive
+      Merge.merge_constraint_approx ~destructive
         env smty.pmty_loc body id approx_smty
   (* module substitutions are ignored, but checked for cyclicity *)
   | Pwith_module (_, lid') ->
@@ -1450,7 +1458,8 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
         let mty = transl_modtype env smty in
         l, With_modtypesubst mty
   in
-  let (path, lid, constr, sg) = merge_constraint env loc sg lid with_info in
+  let (path, lid, constr, sg) =
+    Merge.merge_constraint env loc sg lid with_info in
   ((path, lid, constr) :: rev_tcstrs, sg)
 
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -438,13 +438,6 @@ let params_are_constrained =
 
 type merge_constraint =
   (* Normal merging cases that returns a typed tree *)
-  | With_module of {
-        lid:Longident.t loc;
-        path:Path.t;
-        md:Types.module_declaration;
-        remove_aliases:bool
-      }
-  | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
   | With_modtype of Types.module_type
   | With_modtypesubst of Types.module_type
 
@@ -532,30 +525,6 @@ module Merge = struct
           let new_item = patch_modtype_item id mtd priv mty in
           let path = Pident id in
           return ~ghosts ~replace_by:new_item path
-      | Sig_module(id, pres, md, rs, priv),
-        With_module {lid=_; md=md'; path; remove_aliases}
-        when Ident.name id = s ->
-          let sig_env = Env.add_signature sg_for_env outer_sig_env in
-          let real_path = Pident id in
-          let mty = md'.md_type in
-          let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
-          let md'' = { md' with md_type = mty } in
-          let newmd = Mtype.strengthen_decl ~aliasable:false
-              sig_env md'' path in
-          ignore(Includemod.modtypes  ~mark:true ~loc sig_env
-                   newmd.md_type md.md_type);
-          return ~ghosts
-            ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-            real_path
-      | Sig_module(id, _, md, _rs, _), With_modsubst (_,path,md')
-        when Ident.name id = s ->
-          let sig_env = Env.add_signature sg_for_env outer_sig_env in
-          let real_path = Pident id in
-          let aliasable = not (Env.is_functor_arg path sig_env) in
-          ignore
-            (Includemod.strengthened_module_decl ~loc ~mark:true
-               ~aliasable sig_env md' path md);
-          return ~ghosts ~replace_by:None real_path
       | _ -> None
 
   (* Main recursive knot to handle deep merges *)
@@ -720,13 +689,32 @@ module Merge = struct
   (* md' is the module type of the module at [path], used for equiv checks *)
   let merge_module ~destructive env loc sg lid
       (md': Types.module_declaration) path remove_aliases =
-    let constr =
-      if not destructive then
-        With_module {lid; path; md=md'; remove_aliases}
-      else
-        With_modsubst (lid, path, md')
+    let patch item s sig_env sg_for_env ~ghosts =
+      match item with
+      | Sig_module(id, pres, md, rs, priv) when Ident.name id = s ->
+          let sig_env = Env.add_signature sg_for_env sig_env in
+          let real_path = Pident id in
+          if destructive then
+            let aliasable = not (Env.is_functor_arg path sig_env) in
+            (* Inclusion check with the strengthened definition *)
+            let _ =
+              Includemod.strengthened_module_decl ~loc ~mark:true
+                ~aliasable sig_env md' path md in
+            return ~ghosts ~replace_by:None real_path
+          else
+            let mty = md'.md_type in
+            let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
+            let md'' = { md' with md_type = mty } in
+            let newmd =
+              Mtype.strengthen_decl ~aliasable:false sig_env md'' path in
+            (* Inclusion check with the original signature *)
+            let _ = Includemod.modtypes ~mark:true ~loc sig_env
+                newmd.md_type md.md_type in
+            return ~ghosts
+              ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
+              real_path
+      | _ -> None
     in
-    let patch = patch_all ~destructive loc constr in
     let real_path,paths,_,sg = merge ~patch ~destructive env sg loc lid in
     let replace s p = Subst.Unsafe.add_module_path p path s in
     let sg = post_process ~destructive loc lid env paths sg replace in


### PR DESCRIPTION
This PR proposes a refactoring of the `merge_constraint` function, which handles signatures constraints.

# Context

Constraints are modifiers that act on module types. There are of three forms of constraints :
- **type** constraint `... with type t = ...`
- **module** constraint `... with module X = ...`
- **module type** constraints `... with module type T = ...`

Each constraint can be *destructive*, (with the syntax `:=`) meaning that the substituted identifier is removed from the signature. This imposes additional checks to ensure wellformedness in the absence of the destructed item.

Each constraint can be *deep*, meaning that the substituted identifier might be inside a submodule (`... with type X.Y.t = ...`). 

Each constraint can be *instantiating*, if the substitution replaces an "*abstract*" field (for module constraints, "*abstract*" means "*not already an alias*"). If the constraint is not instantiating, equivalence or subtyping checks with the old definition are performed.

Finally, merging is used both in (1) "normal" mode, to build a typed tree, in (2) "approx" mode, during the signature approximation phase of typechecking recursive modules, and in (3) "package" mode, for checking signatures of first-class modules.

# Refactoring

The refactoring is limited to `typemod.ml`. It consists of : 
1. Creating a `Merge` module to gather the merge related functions
2. Extract the mutually recursive functions `patch_deep_item` and `merge_signature` to handle deep constraints
3. Create separated (non-recursive) functions `merge_type`, `merge_module` and `merge_modtype`.
4. Add documentation comments

Now, the structure is similar for each form of merging:
1. A `patch` function is defined to identify the item to substitute, do the equivalence checks if needed, and optionally build the new replacement item (if the substitution is non-destructive)
2. The patch is applied to the module type by using the general `merge` function. It returns the path of the affected item (along with the list of all suffixes, if the substitution was deep).
3. Some post processing is applied (actual replacement for destructive substitutions, wellformedness checks) 

# Semantic changes

The only visible change is the introduction of a new error when doing deep destructive substitutions inside aliases signatures, as in : 
```ocaml
module X = sig type t = int val x : t end 
module type T = sig module Y = X end with type Y.t := int
```
Throws a new error `With_lost_alias` : 
 ```
 Error: This deep destructive "with" substitution inside of "Y" would
       loose the aliasing to "X" .
```